### PR TITLE
Update to latest snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id "java" //This is a java project, scala and groovy plugins also exist
     id "nova.gradle" version "0.2.6" //Use the NOVA Gradle plugin version 0.2.6
 }
-apply from: "https://raw.githubusercontent.com/NOVA-Team/NOVA-Gradle/master/shared-scripts/java.gradle"
 
 dependencies { //Dependencies of this project
     compile nova(nova_version) //Depend on NOVA for compiling
@@ -24,11 +23,6 @@ nova { //This block is used for configuring the NOVA Gradle plugin
 		//Wrapper profile for MC 1.8
 		"18" {
 			wrapper "nova.core:NOVA-Core-Wrapper-MC1.8:${nova_version}"
-		}
-
-		//Wrapper profile for MC 1.11
-		"1_11" {
-			wrapper "nova.core:NOVA-Core-Wrapper-MC1.11:${nova_version}"
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,26 +9,26 @@ dependencies { //Dependencies of this project
 }
 
 nova { //This block is used for configuring the NOVA Gradle plugin
-    wrappers { //Configures wrapper profiles
+	wrappers { //Configures wrapper profiles
 		/**
-         * This profile is called "17", you can skip the quotes if it's not numbers.
-         * This profile for example will generate the "run17Client" gradle task and create an IDEA
-         * config of the same name.
-         * The name can be changed to your liking.
-         */
-        //Wrapper profile for MC 1.7.10
-        "17" {
-            wrapper "nova.core:NOVA-Core-Wrapper-MC1.7:${nova_version}"
-        }
+		 * This profile is called "17", you can skip the quotes if it's not numbers.
+		 * This profile for example will generate the "run17Client" gradle task and create an IDEA
+		 * config of the same name.
+		 * The name can be changed to your liking.
+		 */
+		//Wrapper profile for MC 1.7.10
+		"17" {
+			wrapper "nova.core:NOVA-Core-Wrapper-MC1.7:${nova_version}"
+		}
 
-        //Wrapper profile for MC 1.8
-        "18" {
-            wrapper "nova.core:NOVA-Core-Wrapper-MC1.8:${nova_version}"
-        }
+		//Wrapper profile for MC 1.8
+		"18" {
+			wrapper "nova.core:NOVA-Core-Wrapper-MC1.8:${nova_version}"
+		}
 
-        //Wrapper profile for MC 1.11
-        "1_11" {
-            wrapper "nova.core:NOVA-Core-Wrapper-MC1.11:${nova_version}"
-        }
-    }
+		//Wrapper profile for MC 1.11
+		"1_11" {
+			wrapper "nova.core:NOVA-Core-Wrapper-MC1.11:${nova_version}"
+		}
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,34 @@
 plugins {
-    id "java"
-    id "nova.gradle" version "0.2.6"
+    id "java" //This is a java project, scala and groovy plugins also exist
+    id "nova.gradle" version "0.2.6" //Use the NOVA Gradle plugin version 0.2.6
+}
+apply from: "https://raw.githubusercontent.com/NOVA-Team/NOVA-Gradle/master/shared-scripts/java.gradle"
+
+dependencies { //Dependencies of this project
+    compile nova(nova_version) //Depend on NOVA for compiling
 }
 
-dependencies {
-    compile nova("0.1.0-SNAPSHOT")
-}
-
-nova {
-    wrappers {
+nova { //This block is used for configuring the NOVA Gradle plugin
+    wrappers { //Configures wrapper profiles
+		/**
+         * This profile is called "17", you can skip the quotes if it's not numbers.
+         * This profile for example will generate the "run17Client" gradle task and create an IDEA
+         * config of the same name.
+         * The name can be changed to your liking.
+         */
+        //Wrapper profile for MC 1.7.10
         "17" {
-            wrapper "nova.core:NOVA-Core-Wrapper-MC1.7:0.1.0-SNAPSHOT"
+            wrapper "nova.core:NOVA-Core-Wrapper-MC1.7:${nova_version}"
         }
+
+        //Wrapper profile for MC 1.8
         "18" {
-            wrapper "nova.core:NOVA-Core-Wrapper-MC1.8:0.1.0-SNAPSHOT"
+            wrapper "nova.core:NOVA-Core-Wrapper-MC1.8:${nova_version}"
+        }
+
+        //Wrapper profile for MC 1.11
+        "1_11" {
+            wrapper "nova.core:NOVA-Core-Wrapper-MC1.11:${nova_version}"
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,6 @@ version = 0.1.0
 
 # Maven group
 group = net.novaapi.template
+
+# NOVA version
+nova_version = 0.1.0-SNAPSHOT

--- a/src/main/java/net/novaapi/template/TemplateMod.java
+++ b/src/main/java/net/novaapi/template/TemplateMod.java
@@ -1,0 +1,24 @@
+package net.novaapi.template;
+
+import nova.core.block.BlockManager;
+import nova.core.loader.Loadable;
+import nova.core.loader.Mod;
+
+@Mod(id = TemplateMod.MOD_ID, name = TemplateMod.NAME, version = TemplateMod.VERSION, novaVersion = "0.0.1")
+public class TemplateMod implements Loadable {
+	public static final String MOD_ID = "template_mod";
+	public static final String NAME = "Example Mod";
+	public static final String VERSION = "0.1.0";
+
+	public final BlockManager blockManager;
+
+	public TemplateMod(BlockManager blockManager) {
+		this.blockManager = blockManager;
+	}
+
+	@Override
+	public void init() {
+		// some example code
+		System.out.println("AIR BLOCK >> " + this.blockManager.getAirBlock().getID());
+	}
+}


### PR DESCRIPTION
This PR updates the repository to the latest snapshot of NOVA-Core.

I’ve also created a template mod that prints the ID of the Air block to the console. (Forge does something similar, but for the dirt block)